### PR TITLE
Enforce TYPE-to-structure binding in TiGR JSON schemas

### DIFF
--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt.json
@@ -145,5 +145,22 @@
         }
       ]
     }
+  },
+  "if": {
+    "properties": {
+      "Header": {
+        "properties": { "TYPE": { "const": "HEADER_ONLY" } },
+        "required": ["TYPE"]
+      }
+    }
+  },
+  "then": {
+    "properties": {
+      "EvtON": false,
+      "EvtOFF": false,
+      "EvtTRK": false,
+      "EvtLT": false,
+      "Extra": false
+    }
   }
 }

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventLT.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventLT.json
@@ -164,6 +164,10 @@
     },
     "Header": {
       "$ref": "JSONSchema_HeaderEvt.json#/properties/Header"
-    }
+    },
+    "EvtON": false,
+    "EvtOFF": false,
+    "EvtTRK": false,
+    "Extra": false
   }
 }

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventOFF.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventOFF.json
@@ -223,7 +223,11 @@
     },
     "Header": {
       "$ref": "JSONSchema_HeaderEvt.json#/properties/Header"
-    }
+    },
+    "EvtON": false,
+    "EvtTRK": false,
+    "EvtLT": false,
+    "Extra": false
   },
   "if": {
     "properties": {

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventON.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventON.json
@@ -222,7 +222,10 @@
     },
     "Header": {
       "$ref": "JSONSchema_HeaderEvt.json#/properties/Header"
-    }
+    },
+    "EvtOFF": false,
+    "EvtTRK": false,
+    "EvtLT": false
   },
   "if": {
     "properties": {

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventON_Extra.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventON_Extra.json
@@ -274,7 +274,10 @@
     },
     "Header": {
       "$ref": "JSONSchema_HeaderEvt.json#/properties/Header"
-    }
+    },
+    "EvtOFF": false,
+    "EvtTRK": false,
+    "EvtLT": false
   },
   "if": {
     "properties": {

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventTRK.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventTRK.json
@@ -252,6 +252,10 @@
     },
     "Header": {
       "$ref": "JSONSchema_HeaderEvt.json#/properties/Header"
-    }
+    },
+    "EvtON": false,
+    "EvtOFF": false,
+    "EvtLT": false,
+    "Extra": false
   }
 }


### PR DESCRIPTION
Spec 4.1 defines TYPE as "the structure of additional data to be sent with the event" and HEADER_ONLY as "no additional data are defined". The schemas previously did not enforce this: a HEADER_ONLY frame carrying an injected EvtON, or a JOURNEY frame carrying an EvtTRK, validated successfully.

Each schema now explicitly rejects the defined event structures that do not belong to its TYPE ("EvtON": false etc.):

- JSONSchema_HeaderEvt: HEADER_ONLY frames may carry none of EvtON/EvtOFF/EvtTRK/EvtLT/Extra (conditional on Header.TYPE)
- EventON / EventON_Extra: reject EvtOFF/EvtTRK/EvtLT (Extra remains allowed per spec 4.3 fault ON = Header+EvtON+Extra)
- EventOFF: reject EvtON/EvtTRK/EvtLT/Extra (spec 4.3 fault OFF = Header+EvtOFF; spec 6.3.3 scopes EXTRA to fault ON messages)
- EventLT: reject EvtON/EvtOFF/EvtTRK/Extra (spec 5.2)
- EventTRK: reject EvtON/EvtOFF/EvtLT/Extra (spec 5.3)

Deliberately NOT additionalProperties:false - the spec allows "Additional context data may be provided on request" (6.3/7.x), so unknown supplier-specific keys (and example annotations like _comment) must keep validating. Only misplaced spec-defined structures fail.

Verified: all 7 examples in examples/S03P01_TiGR pass; 487 captured production frames (2 vehicles, diesel + full electric) pass; injected misplaced structures are rejected.