### PR TITLE
Tighten field constraints and complete field coverage in TiGR schemas

### DIFF
--- a/schemas/S03P01_TiGR/JSONSchema_Codes.json
+++ b/schemas/S03P01_TiGR/JSONSchema_Codes.json
@@ -411,6 +411,8 @@
         },
         "TTID": {
           "type": ["integer","null"],
+          "minimum": 1,
+          "maximum": 64,
           "title": "The Ttid Schema",          
           "examples": [
             2147483647
@@ -418,6 +420,8 @@
         },
         "TTSTS": {
           "type": ["integer","null"],
+          "minimum": 0,
+          "maximum": 3,
           "title": "The Ttsts Schema",          
           "examples": [
             2147483647
@@ -515,9 +519,10 @@
         },
         "ALTERNATORID": {
           "type": ["string","null"],
+          "pattern": "^[1-4]$",
           "title": "The Alternatorid Schema",
           "examples": [
-            "EA:23"
+            "2"
           ]
         },
         "CELLID": {
@@ -1005,7 +1010,7 @@
           "examples": [
             "EC10"
           ],
-          "pattern": "^[EDFMCT].*$"
+          "pattern": "^[EDFMCT][A-Za-z0-9]{3}$"
         },
         "DST": {
           "type": ["integer","null"],
@@ -1077,12 +1082,20 @@
             ],
             "pattern": "^UTC[+-][0-1][0-9]:[0-5][0-9]$"
         },
-        "TX": {
-          "type": ["integer"],
-          "title": "The Tx Schema",
-          "enum": [0, 1, 3],
+        "TDCC": {
+          "type": ["integer","null"],
+          "title": "The Tdcc Schema",
+          "description": "DCDC cumulated energy (24V network)",
           "examples": [
-            3
+            12
+          ]
+        },
+        "TBCC": {
+          "type": ["integer","null"],
+          "title": "The Tbcc Schema",
+          "description": "Batteries system coolant temperature cumulated energy",
+          "examples": [
+            8
           ]
         },
         "TYPE": {

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt.json
@@ -101,49 +101,7 @@
         "BID": {
           "$ref": "JSONSchema_Codes.json#/properties/BID"
         }
-      },
-      "allOf": [
-        {
-          "if": {
-            "properties": { "TYPE": { "const": "EVENT_ON" } }
-          },
-          "then": {
-            "properties": { "TX": { "enum": [1] } }
-          }
-        },
-        {
-          "if": {
-            "properties": { "TYPE": { "const": "EVENT_OFF" } }
-          },
-          "then": {
-            "properties": { "TX": { "enum": [0] } }
-          }
-        },
-        {
-          "if": {
-            "properties": { "TYPE": { "const": "HEADER_ONLY" } }
-          },
-          "then": {
-            "properties": { "TX": { "enum": [3] } }
-          }
-        },
-        {
-          "if": {
-            "properties": { "TYPE": { "const": "TRACKING" } }
-          },
-          "then": {
-            "properties": { "TX": { "enum": [3] } }
-          }
-        },
-        {
-          "if": {
-            "properties": { "TYPE": { "const": "JOURNEY" } }
-          },
-          "then": {
-            "properties": { "TX": { "enum": [3] } }
-          }
-        }
-      ]
+      }
     }
   }
 }

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventLT.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventLT.json
@@ -151,6 +151,12 @@
         "TSPC": {
           "$ref": "JSONSchema_Codes.json#/properties/TSPC"
         },
+        "TDCC": {
+          "$ref": "JSONSchema_Codes.json#/properties/TDCC"
+        },
+        "TBCC": {
+          "$ref": "JSONSchema_Codes.json#/properties/TBCC"
+        },
         "TCPP": {
           "$ref": "JSONSchema_Codes.json#/properties/TCPP"
         },

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventOFF.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventOFF.json
@@ -195,6 +195,12 @@
         "PSOH": {
           "$ref": "JSONSchema_Codes.json#/properties/PSOH"
         },
+        "PCBS": {
+          "$ref": "JSONSchema_Codes.json#/properties/PCBS"
+        },
+        "MSOH": {
+          "$ref": "JSONSchema_Codes.json#/properties/MSOH"
+        },
         "HADP": {
           "$ref": "JSONSchema_Codes.json#/properties/HADP"
         },


### PR DESCRIPTION
Value constraints (previously unconstrained, letting invalid values validate):
- TTID: minimum 1, maximum 64 (spec 6.3.1 / Annex A "Tell-tale ID [1-64]")
- TTSTS: minimum 0, maximum 3 (spec 6.2.1: monitored TTS conditions 000/001/010/011; 111 "not available" is not monitored)
- ALTERNATORID: pattern ^[1-4]$ per Annex A "the identifier of the alternator [1-4]"; example "EA:23" replaced with "2" (the old example itself contradicted Annex A)
- CODE: pattern ^[EDFMCT].*$ -> ^[EDFMCT][A-Za-z0-9]{3}$ per spec 4.2 "The Event codes consist of 4 alphanumeric"

Missing fields added:
- EvtOFF: PCBS and MSOH (spec 6.3.2 Table 8 [recommended]; the definitions already existed in JSONSchema_Codes.json and were wired into EvtTRK but not EvtOFF)
- EvtLT: TDCC and TBCC (spec 5.2 Table 3 [recommended] for electric/hybrid/hydrogen), with new definitions in JSONSchema_Codes.json modeled like their Table 3 neighbours. Note: Table 3 lists them but the 12.2.2 structure summary does not - a spec-internal inconsistency to resolve editorially.

Removed:
- TX definition in JSONSchema_Codes.json and the five TYPE->TX if/then blocks in JSONSchema_HeaderEvt.json: the v3.0.2 change log says "remove all 'TX' references" but these survived. Inert in practice (TX was not required and absent from production frames).

Verified: all 7 examples pass; 487 captured production frames (diesel
+ full electric vehicles) pass; out-of-range TTID/TTSTS, malformed CODE, and non-[1-4] ALTERNATORID are now rejected.