### PR TITLE
Fix TiGR EventON schema conformance (TTSTS range, PCBS/MSOH fields)

### DIFF
--- a/schemas/S03P01_TiGR/JSONSchema_Codes.json
+++ b/schemas/S03P01_TiGR/JSONSchema_Codes.json
@@ -420,7 +420,7 @@
         },
         "TTSTS": {
           "type": ["integer","null"],
-          "minimum": 0,
+          "minimum": 1,
           "maximum": 3,
           "title": "The Ttsts Schema",          
           "examples": [

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventON.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventON.json
@@ -217,6 +217,12 @@
         },
         "PCBC": {
           "$ref": "JSONSchema_Codes.json#/properties/PCBC"
+        },
+        "PCBS": {
+          "$ref": "JSONSchema_Codes.json#/properties/PCBS"
+        },
+        "MSOH": {
+          "$ref": "JSONSchema_Codes.json#/properties/MSOH"
         }
       }
     },

--- a/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventON_Extra.json
+++ b/schemas/S03P01_TiGR/JSONSchema_HeaderEvt_EventON_Extra.json
@@ -218,6 +218,12 @@
         },
         "PCBC": {
           "$ref": "JSONSchema_Codes.json#/properties/PCBC"
+        },
+        "PCBS": {
+          "$ref": "JSONSchema_Codes.json#/properties/PCBS"
+        },
+        "MSOH": {
+          "$ref": "JSONSchema_Codes.json#/properties/MSOH"
         }
       }
     },


### PR DESCRIPTION
Four conformance gaps in the S03P01 TiGR JSON schemas vs spec v3.0.2:

- JSONSchema_Codes.json: TTSTS minimum 0 -> 1. The tell-tale condition is [1-RED, 2-YELLOW, 3-INFO] (spec line 7226; FMS 001/010/011 per footnote 31). "000=Off" triggers EVENT_OFF and is never transmitted as a TTSTS value; "111=not available" is not monitored (line 1807). Unavailable is represented as NULL (line 3433), already allowed by the null type. minimum 0 therefore admits a value the spec excludes.

- JSONSchema_HeaderEvt_EventON.json: add PCBS and MSOH $refs to EvtON. Both are spec-defined EvtON fields (12.2.4: "PCBS / 0:1 / integer / Propulsion Battery Cell Balance Status"; "MSOH / 0:1 / integer / HVESP MODULE/PACK State of Health") and are added by changelog line 7448 ("add MSOH & PCBS in tables of 12.2 and 13"). They are already defined in JSONSchema_Codes.json but were never wired into the EvtON structure.

- JSONSchema_HeaderEvt_EventON_Extra.json: add the same PCBS and MSOH $refs to EvtON for parity with EventON.json.